### PR TITLE
salt-master settings

### DIFF
--- a/salt-master/setup.sh
+++ b/salt-master/setup.sh
@@ -13,3 +13,5 @@ key_checker () {
 	tail -f /var/log/salt/master
 }
 
+service salt-master start && key_checker
+

--- a/salt-master/setup.sh
+++ b/salt-master/setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash 
+
+key_checker () {
+	x=1
+	while [ $x -le 250 ]
+		do
+  		salt-key -A -y
+  		x=$(( $x + 1 ))
+		sleep 1
+	done
+	echo "All available keys accepted." && salt "*" test.ping && \
+	touch /var/log/salt/master && \
+	tail -f /var/log/salt/master
+}
+


### PR DESCRIPTION
this starts the minion service to call out to the master. Since this is a local container network, it is relatively safe for us to do this, but do notdo this on a production network: We set the master instance to listen for all incoming key requests from minions and automatically accepts them and then tails the Salt master log to STDOUT