### PR TITLE
The salt-minion container needs to be able to resolve salt-master to …

### DIFF
--- a/salt-minion/Dockerfile
+++ b/salt-minion/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:trusty
+MAINTAINER Sascha F. Andreichenko <andreichenko@web.de>
+RUN apt-get update && apt-get install -y salt-minion curl
+COPY setup.sh /opt/setup.sh
+ENTRYPOINT ["sh","/opt/setup.sh"]


### PR DESCRIPTION
The salt-minion container needs to be able to resolve salt-master to be able to use it in the minion configuration, which is resolvable by using the --linkflag in the Docker CLI when we create the minion container.
The salt-master must come online first in order to link to it, and this must happen quickly and automatically enough that however many minions we create can send key requests before the server stops responding to new requests and then only tails the master log.